### PR TITLE
added simple arty calculator

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -3,6 +3,7 @@ class CfgFunctions {
     #include "scripts\arsr\funcs.hpp"		// enable sound directionfinder
     #include "scripts\stomper\funcs.hpp"	// enable sitting on Stomper UGV
     #include "scripts\craters\funcs.hpp"	// terrain deformation on artillery impacts
+    #include "scripts\easyarty\funcs.hpp"   // easy azimuth and elevation calculation
 };
 
 

--- a/scripts/easyarty/funcs.hpp
+++ b/scripts/easyarty/funcs.hpp
@@ -2,7 +2,6 @@ class easyarty {
     tag = "easyarty";
     class functions {
         file = "scripts\easyarty\functions";
-        class preInit{preInit = 1;};
         class postInit{postInit = 1;};
         class setTargetPos{};
         class calculate{};

--- a/scripts/easyarty/funcs.hpp
+++ b/scripts/easyarty/funcs.hpp
@@ -1,0 +1,12 @@
+class easyarty {
+    tag = "easyarty";
+    class functions {
+        file = "scripts\easyarty\functions";
+        class preInit{preInit = 1;};
+        class postInit{postInit = 1;};
+        class setTargetPos{};
+        class calculate{};
+        class start{};
+        class stop{};
+    };
+};

--- a/scripts/easyarty/functions/fn_calculate.sqf
+++ b/scripts/easyarty/functions/fn_calculate.sqf
@@ -4,15 +4,14 @@ params ["_targetPos", "_vehicle"];
 
 private _az = (_vehicle getDir _targetPos) * DEGREE_TO_MIL_FACTOR;
 
-_distanceToTarget = _vehicle distance artyTarget;
-_distanceRounded = _distanceToTarget - _distanceToTarget % 100;
-_distanceFactor = _distanceToTarget % 100 * -0.01; //used to scale later
+private _distanceToTarget = _vehicle distance artyTarget;
+private _distanceRounded = _distanceToTarget - _distanceToTarget % 100;
+private _distanceFactor = _distanceToTarget % 100 * -0.01; //used to scale later
 
 (ace_artillerytables_magModeData select ace_artillerytables_lastCharge) params [["_muzzleVelocity", -1], ["_airFriction", 0]];
-_elevMin = 10;
-_elevMax = 75;
-_lastElevMode = true; //always shoot high for now
-
+private _elevMin = 10;
+private _elevMax = 75;
+private _lastElevMode = param [0, ace_artillerytables_lastElevationMode];
 private _ret = "ace_artillerytables" callExtension ["start", [_muzzleVelocity,_airFriction,_elevMin,_elevMax,_lastElevMode]];
 private _status = 0;
 private _result = [];
@@ -25,7 +24,7 @@ while { _status != 3 } do {
 	};
 };
 
-_resultLength = count _result;
+private _resultLength = count _result;
 
 if (_resultLength < 3) exitWith {[]};
 

--- a/scripts/easyarty/functions/fn_calculate.sqf
+++ b/scripts/easyarty/functions/fn_calculate.sqf
@@ -1,0 +1,46 @@
+params ["_targetPos", "_vehicle"];
+
+#define DEGREE_TO_MIL_FACTOR 17.7777777778
+
+private _az = (_vehicle getDir _targetPos) * DEGREE_TO_MIL_FACTOR;
+
+_distanceToTarget = _vehicle distance artyTarget;
+_distanceRounded = _distanceToTarget - _distanceToTarget % 100;
+_distanceFactor = _distanceToTarget % 100 * -0.01; //used to scale later
+
+(ace_artillerytables_magModeData select ace_artillerytables_lastCharge) params [["_muzzleVelocity", -1], ["_airFriction", 0]];
+_elevMin = 10;
+_elevMax = 75;
+_lastElevMode = true; //always shoot high for now
+
+private _ret = "ace_artillerytables" callExtension ["start", [_muzzleVelocity,_airFriction,_elevMin,_elevMax,_lastElevMode]];
+private _status = 0;
+private _result = [];
+
+while { _status != 3 } do {
+    _ret = ("ace_artillerytables" callExtension ["getline", []]);
+    _status = _ret select 1;
+	if (_status == 1) then {
+	    _result pushBack parseSimpleArray (_ret select 0);
+	};
+};
+
+_resultLength = count _result;
+
+if (_resultLength < 3) exitWith {[]};
+
+private _minResult = parseNumber (_result select 0 select 0);
+private _maxResult = parseNumber (_result select _resultLength-1 select 0);
+
+if (_distanceToTarget > _maxResult || {_distanceToTarget < _minResult}) exitWith { [] };
+
+private _idxLower = (_distanceRounded - _minResult) / 100; 
+private _idxUpper = (_distanceRounded + 100 - _minResult) / 100;
+
+private _lSolution = _result select _idxLower;
+private _uSolution = _result select _idxUpper;
+
+private _diffElevation = parseNumber (_lSolution select 1) - parseNumber (_uSolution select 1);
+private _finalElevation = parseNumber (_lSolution select 1) + _diffElevation * _distanceFactor;
+
+[_finalElevation, _az, _distanceToTarget];

--- a/scripts/easyarty/functions/fn_calculate.sqf
+++ b/scripts/easyarty/functions/fn_calculate.sqf
@@ -4,14 +4,15 @@ params ["_targetPos", "_vehicle"];
 
 private _az = (_vehicle getDir _targetPos) * DEGREE_TO_MIL_FACTOR;
 
-private _distanceToTarget = _vehicle distance artyTarget;
-private _distanceRounded = _distanceToTarget - _distanceToTarget % 100;
-private _distanceFactor = _distanceToTarget % 100 * -0.01; //used to scale later
+private _deltaDistance = _vehicle distance2d _targetPos;
+private _distanceRounded = _deltaDistance - _deltaDistance % 100;
+private _distanceFactor = _deltaDistance % 100 * 0.01;
+private _heightFactor = ((getPosASL _vehicle select 2) - getTerrainHeightASL _targetPos) / 100 * -1;
 
 (ace_artillerytables_magModeData select ace_artillerytables_lastCharge) params [["_muzzleVelocity", -1], ["_airFriction", 0]];
 private _elevMin = 10;
 private _elevMax = 75;
-private _lastElevMode = param [0, ace_artillerytables_lastElevationMode];
+private _lastElevMode = ace_artillerytables_lastElevationMode;
 private _ret = "ace_artillerytables" callExtension ["start", [_muzzleVelocity,_airFriction,_elevMin,_elevMax,_lastElevMode]];
 private _status = 0;
 private _result = [];
@@ -31,7 +32,7 @@ if (_resultLength < 3) exitWith {[]};
 private _minResult = parseNumber (_result select 0 select 0);
 private _maxResult = parseNumber (_result select _resultLength-1 select 0);
 
-if (_distanceToTarget > _maxResult || {_distanceToTarget < _minResult}) exitWith { [] };
+if (_deltaDistance > _maxResult || {_deltaDistance < _minResult}) exitWith { [] };
 
 private _idxLower = (_distanceRounded - _minResult) / 100; 
 private _idxUpper = (_distanceRounded + 100 - _minResult) / 100;
@@ -40,6 +41,14 @@ private _lSolution = _result select _idxLower;
 private _uSolution = _result select _idxUpper;
 
 private _diffElevation = parseNumber (_lSolution select 1) - parseNumber (_uSolution select 1);
-private _finalElevation = parseNumber (_lSolution select 1) + _diffElevation * _distanceFactor;
+private _hightOffset = _lSolution select 2;
+_hightOffset = [1, parseNumber _hightOffset] select (_hightOffset isNotEqualTo "-");
 
-[_finalElevation, _az, _distanceToTarget];
+private _tof = _lSolution select 4;
+
+// in high mode less elevation is father, in low it is the opposite.
+// in high mode we subtract to gain range, in low mode we need to add
+// because - * a negative number (see diff calc) is like adding, this works for both cases
+private _finalElevation = parseNumber (_lSolution select 1) - _diffElevation * _distanceFactor - _hightOffset * _heightFactor;
+
+[_finalElevation, _az, _deltaDistance, _tof];

--- a/scripts/easyarty/functions/fn_postInit.sqf
+++ b/scripts/easyarty/functions/fn_postInit.sqf
@@ -1,0 +1,64 @@
+if (isDedicated) exitWith {};
+easyArtyRunning = false;
+easyArtyPfh = -1;
+easyArtyDisplayEh = -1;
+
+private _spacerAction = [
+    "spacerEasyArty",
+    "Easy Arty",
+    "",
+    {},
+    {true}
+] call ace_interact_menu_fnc_createAction;
+
+private _startAction = [
+    "startEasyArty",
+    "Start calculate",
+    "",
+    {[] spawn easyarty_fnc_start;},
+    {!easyArtyRunning}    
+] call ace_interact_menu_fnc_createAction;
+
+private _stopAction = [
+    "stopEasyArty",
+    "Stop calculation",
+    "",
+    {[] call easyarty_fnc_stop;},
+    {easyArtyRunning}    
+] call ace_interact_menu_fnc_createAction;
+
+private _assignPosAction = [
+    "assingPosEasyArty",
+    "Assign new target",
+    "",
+    {[] spawn easyarty_fnc_setTargetPos;},
+    {easyArtyRunning}    
+] call ace_interact_menu_fnc_createAction;
+
+[
+    player,
+    1,
+    ["ACE_SelfActions"],
+    _spacerAction
+] call ace_interact_menu_fnc_addActionToObject;
+
+[
+    player,
+    1,
+    ["ACE_SelfActions", "spacerEasyArty"],
+    _startAction
+] call ace_interact_menu_fnc_addActionToObject;
+
+[
+    player,
+    1,
+    ["ACE_SelfActions", "spacerEasyArty"],
+    _stopAction
+] call ace_interact_menu_fnc_addActionToObject;
+
+[
+    player,
+    1,
+    ["ACE_SelfActions", "spacerEasyArty"],
+    _assignPosAction
+] call ace_interact_menu_fnc_addActionToObject;

--- a/scripts/easyarty/functions/fn_postInit.sqf
+++ b/scripts/easyarty/functions/fn_postInit.sqf
@@ -1,10 +1,11 @@
-if (isDedicated) exitWith {};
-easyArtyRunning = false;
-easyArtyPfh = -1;
-easyArtyDisplayEh = -1;
+if !(hasinterface) exitWith {};
+
+easyarty_running = false;
+easyarty_pfh = -1;
+easyarty_displayEh = -1;
 
 private _spacerAction = [
-    "spacerEasyArty",
+    "easyarty_spacer",
     "Easy Arty",
     "",
     {},
@@ -12,53 +13,57 @@ private _spacerAction = [
 ] call ace_interact_menu_fnc_createAction;
 
 private _startAction = [
-    "startEasyArty",
+    "easyarty_start",
     "Start calculate",
     "",
     {[] spawn easyarty_fnc_start;},
-    {!easyArtyRunning}    
+    {!easyarty_running}    
 ] call ace_interact_menu_fnc_createAction;
 
 private _stopAction = [
-    "stopEasyArty",
+    "easyarty_stop",
     "Stop calculation",
     "",
     {[] call easyarty_fnc_stop;},
-    {easyArtyRunning}    
+    {easyarty_running}    
 ] call ace_interact_menu_fnc_createAction;
 
-private _assignPosAction = [
-    "assingPosEasyArty",
+private _newTargetAction = [
+    "easyarty_newTarget",
     "Assign new target",
     "",
     {[] spawn easyarty_fnc_setTargetPos;},
-    {easyArtyRunning}    
+    {easyarty_running}    
 ] call ace_interact_menu_fnc_createAction;
 
 [
-    player,
+    "Man",
     1,
     ["ACE_SelfActions"],
-    _spacerAction
-] call ace_interact_menu_fnc_addActionToObject;
+    _spacerAction,
+    true
+] call ace_interact_menu_fnc_addActionToClass;
 
 [
-    player,
+    "Man",
     1,
-    ["ACE_SelfActions", "spacerEasyArty"],
-    _startAction
-] call ace_interact_menu_fnc_addActionToObject;
+    ["ACE_SelfActions", "easyarty_spacer"],
+    _startAction,
+    true
+] call ace_interact_menu_fnc_addActionToClass;
 
 [
-    player,
+    "Man",
     1,
-    ["ACE_SelfActions", "spacerEasyArty"],
-    _stopAction
-] call ace_interact_menu_fnc_addActionToObject;
+    ["ACE_SelfActions", "easyarty_spacer"],
+    _stopAction,
+    true
+] call ace_interact_menu_fnc_addActionToClass;
 
 [
-    player,
+    "Man",
     1,
-    ["ACE_SelfActions", "spacerEasyArty"],
-    _assignPosAction
-] call ace_interact_menu_fnc_addActionToObject;
+    ["ACE_SelfActions", "easyarty_spacer"],
+    _newTargetAction,
+    true
+] call ace_interact_menu_fnc_addActionToClass;

--- a/scripts/easyarty/functions/fn_postInit.sqf
+++ b/scripts/easyarty/functions/fn_postInit.sqf
@@ -9,7 +9,7 @@ private _spacerAction = [
     "Easy Arty",
     "",
     {},
-    {true}
+    {[player, "ACE_artilleryTable"] call BIS_fnc_hasItem}
 ] call ace_interact_menu_fnc_createAction;
 
 private _startAction = [

--- a/scripts/easyarty/functions/fn_setTargetPos.sqf
+++ b/scripts/easyarty/functions/fn_setTargetPos.sqf
@@ -1,0 +1,17 @@
+openMap [true, true];
+
+hint "Click on the map to place a target";
+
+private _mapClickEh = addMissionEventHandler ["MapSingleClick", {
+	params ["", "_pos"];
+	deleteMarker "target_loc";
+	_marker = createMarkerLocal ["target_loc", _pos];
+	_marker setMarkerType "HD_DOT";
+	_marker setMarkerText "Target";
+	artyTarget = _pos;
+	openMap  [false, false];
+}];
+
+waitUntil {!visibleMap};
+
+removeMissionEventHandler ["MapSingleClick", _mapClickEh]

--- a/scripts/easyarty/functions/fn_setTargetPos.sqf
+++ b/scripts/easyarty/functions/fn_setTargetPos.sqf
@@ -4,11 +4,11 @@ hint "Click on the map to place a target";
 
 private _mapClickEh = addMissionEventHandler ["MapSingleClick", {
 	params ["", "_pos"];
-	deleteMarker "target_loc";
-	_marker = createMarkerLocal ["target_loc", _pos];
-	_marker setMarkerType "HD_DOT";
-	_marker setMarkerText "Target";
-	artyTarget = _pos;
+	deleteMarkerLocal "target_loc";
+	private _marker = createMarkerLocal ["target_loc", _pos];
+	_marker setMarkerTypeLocal "HD_DOT";
+	_marker setMarkerTextLocal "Target";
+	easyarty_target = _pos;
 	openMap  [false, false];
 }];
 

--- a/scripts/easyarty/functions/fn_start.sqf
+++ b/scripts/easyarty/functions/fn_start.sqf
@@ -1,0 +1,22 @@
+if (easyArtyRunning) exitWith {};
+if (isNil "ace_artillerytables_magModeData") exitWith { hint "You must have chosen an artillery sheet!" };
+
+call easyarty_fnc_setTargetPos;
+
+easyArtyDisplayEh = (findDisplay 12 displayCtrl 51) ctrlAddEventHandler ["Draw", {
+	(_this select 0) drawLine [
+		getPos player,
+		artyTarget,
+		[0,0,1,1]
+	];
+}];
+
+easyArtyPfh = [{
+	private _solution = [artyTarget, vehicle player] call easyarty_fnc_calculate;
+	if (_solution isEqualTo []) exitwith {
+		hintSilent "No solution found. Please try another range card setting!";
+	};
+	hintSilent format ["=== SOLUTION ===\nDISTANCE: %1\nELEVATION: %2\nAZIMUTH: %3\n", _solution select 2, _solution select 0, _solution select 1];
+}, 1] call CBA_fnc_addPerFrameHandler;
+
+easyArtyRunning = true;

--- a/scripts/easyarty/functions/fn_start.sqf
+++ b/scripts/easyarty/functions/fn_start.sqf
@@ -1,22 +1,22 @@
-if (easyArtyRunning) exitWith {};
-if (isNil "ace_artillerytables_magModeData") exitWith { hint "You must have chosen an artillery sheet!" };
+if (easyarty_running) exitWith {};
+if (isNil "ace_artillerytables_magModeData") exitWith { hint "You must have chosen an artillery solution!" };
 
 call easyarty_fnc_setTargetPos;
 
-easyArtyDisplayEh = (findDisplay 12 displayCtrl 51) ctrlAddEventHandler ["Draw", {
+easyarty_displayEh = (findDisplay 12 displayCtrl 51) ctrlAddEventHandler ["Draw", {
 	(_this select 0) drawLine [
 		getPos player,
-		artyTarget,
+		easyarty_target,
 		[0,0,1,1]
 	];
 }];
 
-easyArtyPfh = [{
-	private _solution = [artyTarget, vehicle player] call easyarty_fnc_calculate;
+easyarty_pfh = [{
+	private _solution = [easyarty_target, vehicle player] call easyarty_fnc_calculate;
 	if (_solution isEqualTo []) exitwith {
 		hintSilent "No solution found. Please try another range card setting!";
 	};
 	hintSilent format ["=== SOLUTION ===\nDISTANCE: %1\nELEVATION: %2\nAZIMUTH: %3\n", _solution select 2, _solution select 0, _solution select 1];
 }, 1] call CBA_fnc_addPerFrameHandler;
 
-easyArtyRunning = true;
+easyarty_running = true;

--- a/scripts/easyarty/functions/fn_start.sqf
+++ b/scripts/easyarty/functions/fn_start.sqf
@@ -16,7 +16,13 @@ easyarty_pfh = [{
 	if (_solution isEqualTo []) exitwith {
 		hintSilent "No solution found. Please try another range card setting!";
 	};
-	hintSilent format ["=== SOLUTION ===\nDISTANCE: %1\nELEVATION: %2\nAZIMUTH: %3\n", _solution select 2, _solution select 0, _solution select 1];
+	hintSilent format [
+		"=== SOLUTION ===\nDISTANCE: %1\nTOF: %2sec\nELEVATION: %3\nAZIMUTH: %4\n", 
+		_solution select 2,
+		_solution select 3, 
+		_solution select 0,
+		_solution select 1
+	];
 }, 1] call CBA_fnc_addPerFrameHandler;
 
 easyarty_running = true;

--- a/scripts/easyarty/functions/fn_stop.sqf
+++ b/scripts/easyarty/functions/fn_stop.sqf
@@ -2,6 +2,6 @@ if (!easyarty_running) exitWith {};
 
 easyarty_pfh call CBA_fnc_removePerFrameHandler;
 (findDisplay 12 displayCtrl 51) ctrlRemoveEventHandler ["Draw", easyarty_displayEh];
-deleteMarker "target_loc";
+deleteMarkerLocal "target_loc";
 
 easyarty_running = false;

--- a/scripts/easyarty/functions/fn_stop.sqf
+++ b/scripts/easyarty/functions/fn_stop.sqf
@@ -1,0 +1,7 @@
+if (!easyArtyRunning) exitWith {};
+
+easyArtyPfh call CBA_fnc_removePerFrameHandler;
+(findDisplay 12 displayCtrl 51) ctrlRemoveEventHandler ["Draw", easyArtyDisplayEh];
+deleteMarker "target_loc";
+
+easyArtyRunning = false;

--- a/scripts/easyarty/functions/fn_stop.sqf
+++ b/scripts/easyarty/functions/fn_stop.sqf
@@ -1,7 +1,7 @@
-if (!easyArtyRunning) exitWith {};
+if (!easyarty_running) exitWith {};
 
-easyArtyPfh call CBA_fnc_removePerFrameHandler;
-(findDisplay 12 displayCtrl 51) ctrlRemoveEventHandler ["Draw", easyArtyDisplayEh];
+easyarty_pfh call CBA_fnc_removePerFrameHandler;
+(findDisplay 12 displayCtrl 51) ctrlRemoveEventHandler ["Draw", easyarty_displayEh];
 deleteMarker "target_loc";
 
-easyArtyRunning = false;
+easyarty_running = false;


### PR DESCRIPTION
Implemented my idea from #2 
![20220928020216_1](https://user-images.githubusercontent.com/18582939/192658763-78f8fe41-141c-42d8-b17d-95f1eb39503c.jpg)

It works together with the artillery table, or more say more clearly, it does not work without one.
First you select your charge from the table, then head over to self interact -> easy arty -> start. 
Just click on the map and a solution will be shown if available. Otherwise a error message will be shown. 
You can switch the charge and your own position and the solution will be updated accordingly.