### PR TITLE
Container spawn randomisation

### DIFF
--- a/scripts/spot-randomizer/functions/fn_placeSupplyStation.sqf
+++ b/scripts/spot-randomizer/functions/fn_placeSupplyStation.sqf
@@ -1,5 +1,14 @@
 params ["_side", "_position"];
 
+
+// apply position randomisation
+private _offsetMin = random [0, 50, 100];
+
+private _roadBlacklist = [_position, 150] call BIS_fnc_nearestRoad;
+// find me  a good spot, by between random min distance and max 150m, ignore positions with roads
+// don't be in the see and if nothing works default to the original provided position
+private _position = [_position, _offsetMin,  150, 15, 0, 0.2, 0, _roadBlacklist, _position] call BIS_fnc_findSafePos;
+
 private _containerType = "";
 private _netType = "";
 switch (_side) do


### PR DESCRIPTION
Attempts to solve the issue with obvious container positions by randomise the container positions a bit.
My thought is a good empty position is better to allow blending in with the terrain. 
If no position is found by the BIS function the default provided position is used.

Further thoughts:
* We could still attempt to try a random direction and distance randomisation because any terrainobjects would be erased, keeping special care about cities and buildings
* Maybe give the random values a CBA setting, eventough i don't think that would be to important here.

Closes #23 