### PR TITLE
ShellTracker Update

### DIFF
--- a/initPlayerServer.sqf
+++ b/initPlayerServer.sqf
@@ -2,4 +2,4 @@ params ["_unit", "_didJIP"];
 diag_log(name _unit + " has joined the game and did JIP? " + str _didJIP);
 
 // Only for JIP to prevent superfluous remoteExecs at mission start. At missionstart, everybody should be registered via regular postInit.
-if (_didJIP) exitWith {remoteExecCall ["shellTracker_fnc_postInit"] }; // Gotta tell everyone to update their trackers, so new/JIP players also get tracked.
+if (_didJIP) exitWith {[[_unit]] remoteExecCall ["shellTracker_fnc_initTracker"] }; // Gotta tell everyone to update their trackers, so new/JIP players also get tracked.

--- a/scripts/shelltracker/funcs.hpp
+++ b/scripts/shelltracker/funcs.hpp
@@ -3,6 +3,7 @@ class shelltracker {
     class functions {
         file = "scripts\shelltracker\functions";
         class postInit{postInit = 1;};
+        class initTracker{};
         class onFired{};
         class addFiredEH{};
     };

--- a/scripts/shelltracker/functions/fn_initTracker.sqf
+++ b/scripts/shelltracker/functions/fn_initTracker.sqf
@@ -8,8 +8,6 @@ This function needs to be run whenever allPlayers changes (especially when new o
 
 if !(hasInterface) exitWith {};
 
-diag_log("_this in initTracker is:");
-diag_log(_this);
 params [["_unitsToUpdate", allPlayers, [[]]]];
 
 private _fnc = {
@@ -18,8 +16,6 @@ private _fnc = {
     // Especially important for mortars, which can be "destroyed" and remade by packing them into backpacks, losing any existing EHs.
     // Would also work if vehicle respawn mechanics get added later on.
     // EHs are stored per object using setVariable to ensure we never double-add EHs by accident
-    diag_log("_this in initTracker _fnc is:");
-    diag_log(_this);
     {
         // If already set up for this unit, we skip. We must check if EH actually exists, bc it gets lost during respawn.
         if (!(isNil {_x getVariable "shelltracker_GetIn_idx"}) && (_x getEventHandlerInfo ["GetInMan", _x getVariable "shelltracker_GetIn_idx"] select 0)) then { continue };

--- a/scripts/shelltracker/functions/fn_initTracker.sqf
+++ b/scripts/shelltracker/functions/fn_initTracker.sqf
@@ -1,0 +1,47 @@
+/*
+Inits the tracker for Zeus only.
+This does NOT handle the case where a Zeus gets his CuratorLogic unassigned. If this becomes a requirement, this script needs to remove the EHs instead of just skipping.
+If an array of units is given as parameter, it will be initialized only for those. If not, it will check allPlayers.
+Whenever a player fires an artillery round, we want them shown for Zeus so they can track things easily.
+This function needs to be run whenever allPlayers changes (especially when new ones join) or when someone respawns!!!
+*/
+
+if !(hasInterface) exitWith {};
+
+diag_log("_this in initTracker is:");
+diag_log(_this);
+params [["_unitsToUpdate", allPlayers, [[]]]];
+
+private _fnc = {
+    if (isNull(getAssignedCuratorLogic player)) exitWith {}; // Only Zeus gets to see this for now. Maybe CMD/sensor as well, later on?
+    // Kind of a workaround to ensure we register with every vehicle out there.
+    // Especially important for mortars, which can be "destroyed" and remade by packing them into backpacks, losing any existing EHs.
+    // Would also work if vehicle respawn mechanics get added later on.
+    // EHs are stored per object using setVariable to ensure we never double-add EHs by accident
+    diag_log("_this in initTracker _fnc is:");
+    diag_log(_this);
+    {
+        // If already set up for this unit, we skip. We must check if EH actually exists, bc it gets lost during respawn.
+        if (!(isNil {_x getVariable "shelltracker_GetIn_idx"}) && (_x getEventHandlerInfo ["GetInMan", _x getVariable "shelltracker_GetIn_idx"] select 0)) then { continue };
+        private _getinidx = _x addEventHandler [ "GetInMan", {
+            params ["_unit", "_role", "_vehicle", "_turret"];
+            // TODO: We could add a vehicle filter here, to ensure we only init the tracker for artillery vehicles. Would also cut down amount of function calls.
+            // if (_vehicle in ["VEHICLE NAME", "VEHICLE NAME", ...] exitWith{};
+            _vehicle call shelltracker_fnc_addFiredEH;
+        }];
+        _x setVariable ["shelltracker_GetIn_idx", _getinidx];
+    } foreach _this;
+};
+
+// CuratorLogic only gets assigned a short interval after mission start, so this stupid workaround is necessary
+if (time < 3) then {
+    [_unitsToUpdate, _fnc] spawn {
+        params ["_unitsToUpdate", "_fnc"];
+
+        sleep 3;
+        _unitsToUpdate call _fnc;
+    };
+} else {
+    _unitsToUpdate call _fnc;
+};
+

--- a/scripts/shelltracker/functions/fn_postInit.sqf
+++ b/scripts/shelltracker/functions/fn_postInit.sqf
@@ -1,32 +1,12 @@
-// Whenever a player fires an artillery round, we want them shown for Zeus so they can track things easily.
-// This function needs to be run whenever allPlayers changes (especially when new ones join)!!!
 if !(hasInterface) exitWith {};
 
-private _fnc = {
-    if (isNull(getAssignedCuratorLogic player)) exitWith {}; // Only Zeus gets to see this for now. Maybe CMD/sensor as well, later on?
-    // Kind of a workaround to ensure we register with every vehicle out there.
-    // Especially important for mortars, which can be "destroyed" and remade by packing them into backpacks, losing any existing EHs.
-    // Would also work if vehicle respawn mechanics get added later on.
-    // EHs are stored per object using setVariable to ensure we never double-add EHs by accident
-    {
-        if !(isNil {_x getVariable "shelltracker_GetIn_idx"}) then { continue }; // Already set up for this unit, we can skip
-        private _getinidx = _x addEventHandler [ "GetInMan", {
-            params ["_unit", "_role", "_vehicle", "_turret"];
-            // TODO: We could add a vehicle filter here, to ensure we only init the tracker for artillery vehicles. Would also cut down amount of function calls.
-            // if (_vehicle in ["VEHICLE NAME", "VEHICLE NAME", ...] exitWith{};
-            _vehicle call shelltracker_fnc_addFiredEH;
-        }];
-        _x setVariable ["shelltracker_GetIn_idx", _getinidx];
-    } foreach allPlayers;
-};
 
-// CuratorLogic only gets assigned a short interval after mission start, so this stupid workaround is necessary
-if (time < 3) then {
-    _fnc spawn {
-        sleep 3;
-        call _this;
-    };
-} else {
-    call _fnc;
-};
+// Whenever someone dies, we need to ensure all Zeus re-inits the tracker for the new player unit.
+// This is crude, but still much more network efficient than making every client do this work or keeping track of who is actually Zeus at every time.
+// This is run for every player locally.
+player addEventHandler ["Respawn", {
+	params ["_unit", "_corpse"];
+    [[_unit]] remoteExecCall ["shellTracker_fnc_initTracker"];
+}];
 
+call shelltracker_fnc_initTracker;


### PR DESCRIPTION
- Added re-init of GetInMan EH on respawn. Fixes #38
- Added unit-specific re-init handling instead of allPlayers. Improves performance load on respawn/JIP.